### PR TITLE
Install libopenjp2-7 which is required by PIL

### DIFF
--- a/scripts/modep.sh
+++ b/scripts/modep.sh
@@ -207,7 +207,7 @@ install_modui() {
 	echo "$FUNCNAME started"
 	echo
 	cd $MODEP_DIR
-	sudo apt-get install -y python3-pip
+	sudo apt-get install -y python3-pip libopenjp2-7
 	git clone --recursive https://github.com/BlokasLabs/mod-ui.git
 	cd mod-ui
 	sudo pip3 install -r requirements.txt


### PR DESCRIPTION
Installing modep on the latest Raspbian lite, I encountered an error where MOD-UI was not able to start because of a missing library. Installing the raspbian package libopenjp2-7 fixes the issue.