### PR TITLE
Install libopenjp and libtiff for mod ui

### DIFF
--- a/scripts/modep.sh
+++ b/scripts/modep.sh
@@ -207,7 +207,7 @@ install_modui() {
 	echo "$FUNCNAME started"
 	echo
 	cd $MODEP_DIR
-	sudo apt-get install -y python3-pip libopenjp2-7
+	sudo apt-get install -y python3-pip libopenjp2-7 libtiff5
 	git clone --recursive https://github.com/BlokasLabs/mod-ui.git
 	cd mod-ui
 	sudo pip3 install -r requirements.txt

--- a/scripts/modep.sh
+++ b/scripts/modep.sh
@@ -207,7 +207,7 @@ install_modui() {
 	echo "$FUNCNAME started"
 	echo
 	cd $MODEP_DIR
-	sudo apt-get install -y python3-pip
+	sudo apt-get install -y python3-pip libopenjp2-7
 	git clone --recursive https://github.com/BlokasLabs/mod-ui.git
 	cd mod-ui
 	sudo pip3 install -r requirements.txt


### PR DESCRIPTION
talling modep on the latest Raspbian lite, I encountered an error where MOD-UI was not able to start because of missing libraries. Installing the raspbian package libopenjp2-7 and libtiff fixes the issue.